### PR TITLE
fixed left-centered details

### DIFF
--- a/general.css
+++ b/general.css
@@ -7,6 +7,10 @@ p {
 	
 }
 
+li {
+  text-align:center;
+}
+
 .thumbnail {
 	font-family: sans-serif;
 	text-align: center;


### PR DESCRIPTION
 drop down li tab text with general.css change, now li {text-align:center}
